### PR TITLE
create_meta(): List column names with missing descriptions

### DIFF
--- a/R/create_meta.R
+++ b/R/create_meta.R
@@ -51,7 +51,9 @@ create_meta <- function(file_name, table_variable_name, colname_descriptions) {
   )
 
   if (any(colname_descriptions_table$column != colnames(table_variable_name))) {
-    stop(glue("Column names in {file_name}
+    missing_cols_idx <- which(! colnames(table_variable_name) %in% colname_descriptions_table$column)
+    missing_cols <- colnames(table_variable_name)[missing_cols_idx]
+    stop(glue("Column names {paste(missing_cols, collapse = ",")} in {file_name}
               are not all described in colname_descriptions"))
   }
 

--- a/tests/testthat/test-create_meta.R
+++ b/tests/testthat/test-create_meta.R
@@ -22,3 +22,23 @@ test_that("create_meta works", {
   expect_equal(cols_content$description, "description of the column here")
 
 })
+
+test_that("create_meta stops on missing description", {
+  # Generate tmp directory to test function against
+  tmp_dir <- withr::local_tempdir()
+
+  # Create csv files that match the pattern
+  pattern <- "test_data"
+  test_data_frame <- data.frame(x = 1:5, y = 1:5)
+  test_meta <- data.frame("Col_name" = "X", "description" = "description of the column here")
+  write.csv(test_data_frame, file.path(tmp_dir, paste0(pattern, "_1.csv")), row.names = FALSE)
+
+  expect_error(
+    create_meta(
+      file_name = file.path(tmp_dir, paste0(pattern, "_1.csv")),
+      table_variable_name = test_data_frame,
+      colname_descriptions = c("x" = "description of the column here")
+    ),
+    "Column names .+ in"
+  )
+})


### PR DESCRIPTION
`create_meta()` lists which columns are missing descriptions. 

Test that checks that the function stops if a description is missing.